### PR TITLE
Fix possible race condition

### DIFF
--- a/lib/filequeue.rb
+++ b/lib/filequeue.rb
@@ -22,12 +22,12 @@ class FileQueue
   def pop
     value = nil
     rest = nil
-    safe_open 'r' do |file|
+    safe_open 'r+' do |file|
       value = file.gets @delimiter
       rest = file.read
-    end
-    safe_open 'w+' do |file|
+      file.rewind
       file.write rest
+      file.truncate(file.pos)
     end
     value ? value[0..-(@delimiter.length) - 1] : nil
   end


### PR DESCRIPTION
FileQueue#pop would lock the queue file and read the first line and remainder of the file. It would then unlock, then relock to write the remainder of the file.

During this brief unlocked phase, another thread could also attempt a pop, read the first line and remainder, and then being the writing phase. This would result in duplicate items being popped off the queue.

Instead, we're opening the file read-write, locking the file, and doing all reading and modification while locked.
